### PR TITLE
Removed word 'backup' from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,13 +20,13 @@ Backup the ``example.com`` zone to a ``CSV`` file.
 
 ::
 
-    route53-transfer backup example.com backup.csv
+    route53-transfer dump example.com backup.csv
 
 Use STDOUT instead of a file
 
 ::
 
-    route53-transfer backup example.com -
+    route53-transfer dump example.com -
 
 Restore a zone
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Guys,

On your help it is appearing dump, but on your readme is backup. Just to clarify the README.
