### PR TITLE
Don't need to check keys when using IAM roles

### DIFF
--- a/route53_transfer/__init__.py
+++ b/route53_transfer/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.1"
+__version__ = "0.1.1-affirm"

--- a/route53_transfer/app.py
+++ b/route53_transfer/app.py
@@ -39,8 +39,6 @@ def get_aws_credentials(params):
             secret_key = f.read().strip()
     else:
         secret_key = params.get('--secret-key') or environ.get('AWS_SECRET_ACCESS_KEY')
-    if not (access_key and secret_key):
-        exit_with_error('ERROR: Invalid AWS credentials supplied.')
     return access_key, secret_key
 
 def get_zone(con, zone_name):


### PR DESCRIPTION
The extra check is unnecessary and prevents use on EC2 when using IAM roles.