### PR TITLE
Documented load() and dump() functions in README, and tweaked API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,17 @@ Dump from one account, load into another.
     route53-transfer --access-key-id=ACCOUNT1 --secret-key=SECRET dump example.com
     route53-transfer --access-key-id=ACCOUNT2 --secret-key=SECRET load example.com
 
+In Python
+~~~~~~~~~
+
+Use the `load` and `dump` functions to move data.
+
+::
+
+    from StringIO import StringIO
+    from route53_transfer import load, dump
+    from boto import route53
+    
+    out = StringIO()
+    con = route53.connect_to_region('universal')
+    dump(con, 'example.com', out)

--- a/route53_transfer/__init__.py
+++ b/route53_transfer/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "0.1.1-affirm"
+
+from app import load, dump


### PR DESCRIPTION
To use `load()` and `dump()` from inside Python scripts, this PR moves both functions to the top level of `route53_transfer`, and slightly modifies function parameters to accept file-like objects such as `StringIO` buffers.