### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto==2.6.0
-docopt==0.5.0
+boto==2.38.0
+docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto==2.38.0
-docopt==0.6.2
+boto>=2.6.0
+docopt>=0.5.0


### PR DESCRIPTION
When we install route53-transfer, it downgrades `boto` and `docopt` if already installed.

Also another option would be to mention both without specifying a version.

What do you prefer?